### PR TITLE
Sync process loop time with TTL if set to auto

### DIFF
--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -292,14 +292,12 @@ if __name__ == '__main__':
             if (sys.argv[1] == "--repeat"):
                 delay = 300 if ttl == 1 else ttl
                 if ipv4_enabled and ipv6_enabled:
-                    print(
-                        "🕰️ Updating IPv4 (A) & IPv6 (AAAA) records every " + str(delay) + " seconds")
+                    ip_config = "IPv4 (A) & IPv6 (AAAA)"
                 elif ipv4_enabled and not ipv6_enabled:
-                    print("🕰️ Updating IPv4 (A) records every " +
-                          str(delay) + " seconds")
+                    ip_config = "IPv4 (A)"
                 elif ipv6_enabled and not ipv4_enabled:
-                    print("🕰️ Updating IPv6 (AAAA) records every " +
-                          str(delay) + " seconds")
+                    ip_config = "IPv6 (AAAA)"
+                print(f"🕰️ Updating {ip_config} records every {str(delay)} seconds")
                 next_time = time.time()
                 killer = GracefulExit()
                 prev_ips = None

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -291,13 +291,13 @@ if __name__ == '__main__':
         if (len(sys.argv) > 1):
             if (sys.argv[1] == "--repeat"):
                 delay = 300 if ttl == 1 else ttl
-                if ipv4_enabled and ipv6_enabled:
-                    ip_config = "IPv4 (A) & IPv6 (AAAA)"
-                elif ipv4_enabled and not ipv6_enabled:
-                    ip_config = "IPv4 (A)"
-                elif ipv6_enabled and not ipv4_enabled:
-                    ip_config = "IPv6 (AAAA)"
-                print(f"🕰️ Updating {ip_config} records every {str(delay)} seconds")
+                configured_ipvs = []
+                if ipv4_enabled:
+                    configured_ipvs.append("IPv4 (A)")
+                if ipv6_enabled:
+                    configured_ipvs.append("IPv6 (AAAA)")
+                configured_ipvs = ' & '.join(configured_ipvs)
+                print(f"🕰️ Updating {configured_ipvs} records every {str(delay)} seconds")
                 next_time = time.time()
                 killer = GracefulExit()
                 prev_ips = None

--- a/cloudflare-ddns.py
+++ b/cloudflare-ddns.py
@@ -282,29 +282,30 @@ if __name__ == '__main__':
         try:
             ttl = int(config["ttl"])
         except:
-            ttl = 300  # default Cloudflare TTL
+            ttl = 1  # default Cloudflare TTL
             print(
-                "⚙️ No config detected for 'ttl' - defaulting to 300 seconds (5 minutes)")
+                "⚙️ No config detected for 'ttl' - defaulting to 1 (auto)")
         if ttl < 30:
-            ttl = 1  #
+            ttl = 1
             print("⚙️ TTL is too low - defaulting to 1 (auto)")
         if (len(sys.argv) > 1):
             if (sys.argv[1] == "--repeat"):
+                delay = 300 if ttl == 1 else ttl
                 if ipv4_enabled and ipv6_enabled:
                     print(
-                        "🕰️ Updating IPv4 (A) & IPv6 (AAAA) records every " + str(ttl) + " seconds")
+                        "🕰️ Updating IPv4 (A) & IPv6 (AAAA) records every " + str(delay) + " seconds")
                 elif ipv4_enabled and not ipv6_enabled:
                     print("🕰️ Updating IPv4 (A) records every " +
-                          str(ttl) + " seconds")
+                          str(delay) + " seconds")
                 elif ipv6_enabled and not ipv4_enabled:
                     print("🕰️ Updating IPv6 (AAAA) records every " +
-                          str(ttl) + " seconds")
+                          str(delay) + " seconds")
                 next_time = time.time()
                 killer = GracefulExit()
                 prev_ips = None
                 while True:
                     updateIPs(getIPs())
-                    if killer.kill_now.wait(ttl):
+                    if killer.kill_now.wait(delay):
                         break
             else:
                 print("❓ Unrecognized parameter '" +


### PR DESCRIPTION
> If launched with `python cloudflare-ddns.py --repeat` and the TTL is set to 1 (auto), then the process will loop every 1 second instead of 300 seconds, which is what auto actually means in Cloudflare.

> This change adds a variable separate from `ttl`, which is used for the looping behaviour of the program. I have also reduced some repetition of code.